### PR TITLE
Fix error with virtual orders

### DIFF
--- a/Model/Mailer/Variable/Order.php
+++ b/Model/Mailer/Variable/Order.php
@@ -160,8 +160,8 @@ class Order implements VariablesInterface
         $order = $this->getOrder();
         $this->setProductInOrder($order);
 
-        $order->setIsVirtual(false);
-        $order->setData('is_not_virtual', true);
+        $order->setIsVirtual($order->getIsVirtual());
+        $order->setData('is_not_virtual', !$order->getIsVirtual());
 
         return [
             'order' => $order,


### PR DESCRIPTION
The extension breaks when the order is virtual and doesn't have a shipping address causing the following exception:

Type Error occurred when creating object: Yireo\EmailTester2\Block\Adminhtml\Preview, Argument 1 passed to Magento\Sales\Model\Order\Address\Renderer::format(
) must be an instance of Magento\Sales\Model\Order\Address, null given

Setting the correct order type fixes the issue.