### PR TITLE
Fix access level for messageManager variable

### DIFF
--- a/Controller/Adminhtml/Index/Index.php
+++ b/Controller/Adminhtml/Index/Index.php
@@ -40,7 +40,7 @@ class Index extends Action
     /**
      * @var ManagerInterface
      */
-    private $messageManager;
+    protected $messageManager;
 
     /**
      * @var Config

--- a/Controller/Adminhtml/Index/Send.php
+++ b/Controller/Adminhtml/Index/Send.php
@@ -41,7 +41,7 @@ class Send extends Action
     /**
      * @var MessageManager
      */
-    private $messageManager;
+    protected $messageManager;
 
     /**
      * @var Form


### PR DESCRIPTION
`Fatal error: Access level to Yireo\EmailTester2\Controller\Adminhtml\Index\Send::$messageManager must be protected (as in class Magento\Framework\App\Action\Action) or weaker in vendor/yireo/magento2-emailtester2/Controller/Adminhtml/Index/Send.php on line 24`

Maybe the variables can be removed entirely from Send and Index, but I don't know if that breaks BC with older Magento versions. I checked back to version 2.4.1; which has it as protected.